### PR TITLE
fix: tr illegal byte sequence caused by utf8 locale (Mac OSX default)

### DIFF
--- a/modules.sh
+++ b/modules.sh
@@ -819,7 +819,7 @@ mframe_utils_git_stash_pop() {
 mframe_utils_git_create_temp_branch() {
   mframe_utils_ensure_root_dir
 
-  git_temp_branch=temp_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+  git_temp_branch=temp_$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
   git_main_branch=$(git rev-parse --abbrev-ref HEAD)
 
   mframe_utils_git_stash_push


### PR DESCRIPTION
I get the following error when working with modules: "tr: Illegal byte sequence"

This patch fixes it by forcing C locale when using tr

```
bash-3.2$ make module-update-all
tr: Illegal byte sequence
Module "node-module-apidocs" updated.
audited 5 packages in 1.146s
found 0 vulnerabilities

tr: Illegal byte sequence
Module "node-module-bootstrap" updated.
audited 4 packages in 1.146s
found 0 vulnerabilities
```